### PR TITLE
Hooks

### DIFF
--- a/examples/cmdhook.sh
+++ b/examples/cmdhook.sh
@@ -6,6 +6,7 @@ export _base _dir
 
 # Note: not using set -e or set -u for this example
 
+#shellcheck disable=SC2034
 SOURCEPREFIX="${_dir}/../sh/"
 . "${_dir}/../sh/lib.sh"
 
@@ -23,6 +24,7 @@ posthook() {
   stderr="${1}"
   shift
 
+  #shellcheck disable=SC2086
   cat << EOF >&2
 example post hook
 command: $@
@@ -36,9 +38,13 @@ $(cat ${stderr})
 EOF
 }
 
+#shellcheck disable=SC2034
 CURLPOSTHOOK=posthook
+#shellcheck disable=SC2034
 JQPOSTHOOK=posthook
+#shellcheck disable=SC2034
 RMPOSTHOOK=posthook
+#shellcheck disable=SC2034
 LSPOSTHOOK=posthook
 
 curl uri://isinvalid | jq -r .

--- a/examples/cmdhook.sh
+++ b/examples/cmdhook.sh
@@ -4,51 +4,67 @@ _base=$(basename "$0")
 _dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
 export _base _dir
 
-# Note: not using set -e or set -u for this example
+# Just an example of making this whole hook rigamarole optional if DEBUG is set
+# or not.
+if [ -n "${DEBUG}" ]; then
+  #shellcheck disable=SC2034
+  SOURCEPREFIX="${_dir}/../sh"
+  #shellcheck source=./../sh/lib.sh
+  . "${SOURCEPREFIX}/lib.sh"
 
-#shellcheck disable=SC2034
-SOURCEPREFIX="${_dir}/../sh/"
-. "${_dir}/../sh/lib.sh"
+  # Not used directly but indirectly so shellchecks just being pedantic.
+  #shellcheck disable=SC2034
+  DEFAULTPOSTHOOK="${DEFAULTPOSTHOOK:-defaultposthook}"
 
-trap libcleanup EXIT
-
-wrapcmd curl jq ls rm
-
-posthook() {
-  rc="${1}"
-  shift
-  stdin="${1}"
-  shift
-  stdout="${1}"
-  shift
-  stderr="${1}"
-  shift
-
+  # We don't want word splitting here with this var.
   #shellcheck disable=SC2086
-  cat << EOF >&2
-example post hook
+  wrapcmd ${WRAP:-curl jq ls rm}
+
+  posthook() {
+    rc="${1}"
+    shift
+    stdin="${1}"
+    shift
+    stdout="${1}"
+    shift
+    stderr="${1}"
+    shift
+
+    #shellcheck disable=SC2086
+    cat << EOF >&2
+example post hook begin
+
 command: $@
 rc: $rc
+pwd: $(pwd)
 stdin $stdin:
 $(cat ${stdin})
-stout $stdout:
+stdout $stdout:
 $(cat ${stdout})
-sterr $stderr:
+stderr $stderr:
 $(cat ${stderr})
+
+example post hook end
 EOF
-}
+  }
 
-#shellcheck disable=SC2034
-CURLPOSTHOOK=posthook
-#shellcheck disable=SC2034
-JQPOSTHOOK=posthook
-#shellcheck disable=SC2034
-RMPOSTHOOK=posthook
-#shellcheck disable=SC2034
-LSPOSTHOOK=posthook
+  #shellcheck disable=SC2034
+  {
+    CURLPOSTHOOK="${CURLPOSTHOOK:-posthook}"
+    JQPOSTHOOK="${JQPOSTHOOK:-posthook}"
+    RMPOSTHOOK="${RMPOSTHOOK:-posthook}"
+    LSPOSTHOOK="${LSPOSTHOOK:-posthook}"
+  }
+fi
 
+# Needs to be below the ${DEBUG} block as that would count as an unbound variable if it is not set
+# Note: not using set -e or set -u for this example but here is where you want it.
+# set -eu
+
+# The "actual" script, note you could skip defining your own hook to save some
+# lines but this is a complete example.
 curl uri://isinvalid | jq -r .
-curl -s https://example.com/invalid | jq -r .
+curl -s https://example.com/dne | jq -r .
 
 ls /does/not/exist
 rm /does/not/exist

--- a/examples/cmdhook.sh
+++ b/examples/cmdhook.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+#-*-mode: Shell-script; coding: utf-8;-*-
+_base=$(basename "$0")
+_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
+export _base _dir
+
+# Note: not using set -e or set -u for this example
+
+SOURCEPREFIX="${_dir}/../sh/"
+. "${_dir}/../sh/lib.sh"
+
+trap libcleanup EXIT
+
+wrapcmd curl jq ls rm
+
+posthook() {
+  rc="${1}"
+  shift
+  stdin="${1}"
+  shift
+  stdout="${1}"
+  shift
+  stderr="${1}"
+  shift
+
+  cat << EOF >&2
+example post hook
+command: $@
+rc: $rc
+stdin $stdin:
+$(cat ${stdin})
+stout $stdout:
+$(cat ${stdout})
+sterr $stderr:
+$(cat ${stderr})
+EOF
+}
+
+CURLPOSTHOOK=posthook
+JQPOSTHOOK=posthook
+RMPOSTHOOK=posthook
+LSPOSTHOOK=posthook
+
+curl uri://isinvalid | jq -r .
+curl -s https://example.com/invalid | jq -r .
+
+ls /does/not/exist
+rm /does/not/exist

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,1 @@
+# Examples for how one might use this library of shenanigans

--- a/sh/cmd.sh
+++ b/sh/cmd.sh
@@ -1,0 +1,217 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This command is crazy, however its meant to help debug any executable
+#
+# There are current caveats as well. Those include:
+# - This entirely *breaks* pipes, on purpose, so what was parallel execution
+#   becomes serialized.
+# - This also breaks output to not interleave stdout/stderr, stdout is output
+#   then stderr, if this is an issue this may be improved but for now its non
+#   negotiable.
+# - This also writes out many files and basically invokes a bit of overhead per
+#   call, this too is unavoidable, its a trampoline function that wraps the
+#   command.
+#
+# Arguments to function are simply the non fully prefixed commands to wrap.
+# Note, they *MUST* be on $PATH
+#
+# Of particular note is that if we are run under test, e.g. shellspec
+# we prefix the command name with sut, e.g. wrapcmd foo will result in a
+# trampoline function of sutfoo not foo. This is to enable shellspec
+# itself to be able to unit test the trampoline setup function below.
+#
+# Future enhancements will set this up to write stuff out to a timeline
+# directory of wrapped commands, return codes, stdin/out/err as files.
+#
+# That is a future me task.
+wrapcmd() {
+  # Bit of a cheat to ensure if we're run under set -u we can detect things.
+  # We only do this if DEBUG is set to... whatever doesn't matter the value.
+  # Nop if set and we return.
+  if [ "" = "${DEBUG-}" ]; then
+    return 0
+  fi
+
+  # You need to explicitly opt into system under test behavior (just changes the
+  # function name in the end)
+  SUT=${SUT:-false}
+
+  for cmd in "$@"; do
+    cmdname="${cmd}"
+    # Not really applicable to ${cmdname} in this exec call
+    #shellcheck disable=SC2086
+    uppername="$(echo ${cmdname} | tr '[:lower:]' '[:upper:]')"
+    evalcmd="${cmdname}"
+
+    if $SUT; then
+      cmdname="sut${cmd}"
+    else
+      # Forgive me but I had to use eval for this atrocity, basically if wrapcmd
+      # foo was called this defines FOO as a variable with the full path to
+      # "foo". Aka FOO=/usr/bin/foo, this lets callers get at the underlying
+      # command if needed directly. If in a rather wack way but it works, nobody
+      # NEEDS to source this file unless they want the behavior.
+      #
+      # All this is in the end is this:
+      # FOO=${FOO:-foo}
+      # FOO=$(command -v ${FOO})
+      #
+      # But dynamic for any "foo". Don't focus on it too hard.
+
+      # No shellcheck this should not be quoted
+      #shellcheck disable=SC2086
+      eval ${uppername}="\${${uppername}:-${cmdname}}"
+      # Or this
+      #shellcheck disable=SC2086
+      eval export ${uppername}="\$(command -v \${$uppername})"
+      evalcmd=\$${uppername}
+    fi
+
+    # Define all the default hook functions we might need, note that some
+    # commands might need special defaults. That will be a different file. The
+    # "defaults" will be to act just like the original command with no special hooks.
+    #
+    # The caveat here is simply that we do setup to use a default wrap hook
+    # that does the following iff rc != 0 dumps out to stderr.
+    # - Path of command and its arguments
+    # - return code
+    # - tempfile names used to store stdin/out/err
+    # - and those file(s) content(s)
+    #
+    # Specific hook overrides like for say curl or jq are in another sh library
+    # castle.
+
+    # First hook definition and default env setup is a precondition hook.
+    #
+    # So with wrapcmd foo we get the following uneval'd shell:
+    # FOOPREHOOK=${FOOPREHOOK-}
+    # fooprehook() { [ -n "${FOOPREHOOK}" ] && "${FOOPREHOOK}" "$@" }
+    #
+    # Note this is before any stdin/stdout/stderr detection. All this hook gets
+    # is args. This is *NOT* checked for return codes. Its meant as a way to say
+    # set an env var that might be used in a later hook or even record the date
+    # something ran. Whatever, just its here if needed/useful.
+    #
+    # Every one of these evals this is a non issue shellcheck.
+    #shellcheck disable=SC2086
+    eval ${uppername}PREHOOK="\${${uppername}PREHOOK-}"
+    # # Don't stare too long into the \ abyss just accept the void...
+    eval "${cmd}prehook() { [ -n \"\$${uppername}PREHOOK\" ] && \$${uppername}PREHOOK \"\\\$@\"; }"
+
+    # Second hook defined exists to allow for a use case of:
+    # I have data passed to the command and need to validate it
+    #
+    # The specific use case here is curl | jq. We don't want to pass stdout from
+    # curl to jq if its say, html or simply "not json".
+    #
+    # This hook exists for that latter reason. It lets a hook determine if/when
+    # it makes sense to run the requisite command.
+    #
+    # So with that in mind the uneval'd shell looks like so:
+    # FOOVALIDATEHOOK=${FOOVALIDATEHOOK-}
+    # foovalidatehook() { if [ -n "${FOOVALIDATEHOOK}" ]; then return "${FOOVALIDATEHOOK}" "$@"; else return 0; fi }
+    #
+    # The wrapper function will exit early based on this hooks return.
+    # Every one of these evals this is a non issue shellcheck.
+    #shellcheck disable=SC2086
+    eval ${uppername}VALIDATEHOOK="\${${uppername}VALIDATEHOOK-}"
+    # # Don't stare too long into the \ abyss just accept the void...
+    eval "
+${cmd}validatehook() {
+  {
+    set +e
+    if [ -n \"\$${uppername}VALIDATEHOOK\" ]; then
+      \$${uppername}VALIDATEHOOK \"\\\$@\"
+      return $?
+    else
+      return 0
+    fi
+  }
+}"
+
+    # And lastly, the third and final hook defined is basically the PREHOOK only
+    # called right before return Here to do any cleanup you may want in the
+    # PREHOOK really or record executation time whatever. You do you.
+    #shellcheck disable=SC2086
+    eval ${uppername}POSTHOOK="\${${uppername}POSTHOOK-}"
+    # # Don't stare too long into the \ abyss just accept the void...
+    eval "${cmd}posthook() { [ -n \"\$${uppername}POSTHOOK\" ] && \$${uppername}POSTHOOK \$@; }"
+
+    # I want to be clear, this entire things crazy enough as it is but this eval
+    # is not for the faint of heart, here there definitely be dragons, hold onto
+    # your butts.
+
+    # Shellcheck gets super confused by this craziness, its FINE just ignore it.
+    #shellcheck disable=SC2140
+    eval "
+${cmdname}() {
+  ${cmd}prehook \$${evalcmd} \"\$@\"
+
+  if [ ! -t 0 ]; then
+    stdin=\$(libtmpfile stdin-is-a-pipe)
+    cat - /dev/stdin > \$stdin
+  else
+    # Its empty but eh
+    stdin=\$(libtmpfile stdin)
+  fi
+
+  # TODO: Future work to pass in more than just args
+  if ! ${cmd}validatehook \$stdin \$${evalcmd} \"\$@\"; then
+    return $?
+  fi
+
+  if ! [ -t 1 ]; then
+    stdout=\$(libtmpfile stdout-is-a-pipe)
+  else
+    stdout=\$(libtmpfile stdout)
+  fi
+
+  if ! [ -t 2 ]; then
+    stderr=\$(libtmpfile stderr-is-a-pipe)
+  else
+    stderr=\$(libtmpfile stderr)
+  fi
+
+  {
+    # we need to be able to get at failed commands so for this once ensure we
+    # aren't run under set -e, but just here.
+    set +e
+    if [ ! -z \$stdin ]; then
+      ${evalcmd} "\$@" 2> \$stderr 1> \$stdout < \$stdin
+    else
+      \$$evalcmd "\$@" 2> \$stderr 1> \$stdout
+    fi
+  }
+  rc=\$?
+
+  # Cat out stdout first then stderr
+  cat \$stdout >&1
+  cat \$stderr >&2
+
+  ${cmd}posthook \$rc \$stdin \$stdout \$stderr \$${evalcmd} \$@
+  return \$rc
+}"
+  done
+}

--- a/sh/internal.sh
+++ b/sh/internal.sh
@@ -1,3 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 # Where we store all our temp dirs/files for anything this lib does.
 RUNDIR="${RUNDIR:-${TMPDIR:-/tmp}/csm-common-lib-$$}"
 

--- a/sh/internal.sh
+++ b/sh/internal.sh
@@ -1,0 +1,27 @@
+# Where we store all our temp dirs/files for anything this lib does.
+RUNDIR="${RUNDIR:-${TMPDIR:-/tmp}/csm-common-lib-$$}"
+
+# Callers of this script need to call this in an exit handler or temp files
+# created will not be cleaned up.
+#
+# e.g. trap libcleanup EXIT in the calling script
+libcleanup() {
+  ${RM:-rm} -fr "${RUNDIR}"
+}
+
+# Simple wrapper to ensure our rundir is setup. Internal though anyone can call
+# it.
+mkrundir() {
+  install -dm755 "${RUNDIR}"
+}
+
+# Create a tempfile using ${RUNDIR} as the prefix, pass in an arg of what the
+# files prefix name should be. The intended interface for script users.
+libtmpfile() {
+  prefix="${1:-caller-did-not-pick-a-name}"
+  mkrundir
+  tmpfile=$(mktemp -p "${RUNDIR}" "${prefix}-XXXXXXXX")
+  rc=$?
+  echo "${tmpfile}"
+  return "${rc}"
+}

--- a/sh/lib.sh
+++ b/sh/lib.sh
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# All lib shell should Presume to be run with set -e and set -u. Pipes are and
+# should be allowed to fail within this library, pipefile is not portable and
+# shouldn't be depended upon for error checking. If a command fails that needs
+# to be checked not piped into another command.
+
+# Note in posix shell there is no way to know at source time where one is
+# sourced. So we require caller scripts to provide that information in
+# $SOURCEPREFIX as executing shells do have that information.
+
+# Note: Order of imports is important, will eventually automate this.
+. "${SOURCEPREFIX?}/internal.sh"
+. "${SOURCEPREFIX?}/logger.sh"
+. "${SOURCEPREFIX?}/cmd.sh"

--- a/sh/readme.md
+++ b/sh/readme.md
@@ -1,0 +1,31 @@
+# Shell library docs
+
+## Rough design plan (not yet fully implemented)
+
+Premise here is if you want the whole hog just source *sh/lib.sh* after setting SOURCEPREFIX to the directory containing that dir/file. For posix shells there is no way to portably "know" where you were imported from, so we just defer that to calling scripts as they can know where they're importing from.
+
+When you have that you get all the fun stuff.
+
+Eventual goal:
+- Make debugging shell a bit easier and have some standard library of shell to aide in our usage
+
+That will end up with something like scripts having:
+
+```sh
+SOURCEPREFIX=$CWD source ./sh/lib.sh
+
+wrapcmd ls ps curl jq
+
+... stuff
+```
+
+And when called with *DEBUG=anyvalue* and/or *TIMELINE=anyvalue* you will end up with a directory of say */tmp/PARENTPID* with dirs of the epoch start time of any ls, ps, curl or jq call containing:
+- cmdline: The command line of what was called
+- rc: The return code it exited with
+- stdin{-is-a-pipe}: Standard input, and if it was a pipe the filename will reflect that
+- stdout{-is-a-pipe}: Standard output, and if it was a pipe the filename will reflect that
+- stderr{-is-a-pipe}: Standard error, and if it was a pipe the filename will reflect that
+
+That will help with debugging shell scripts that utilize the wrapper functions.
+
+In a near future commit default hooks for the wrapper functions generated will help in output to the screen. For now this is MVP status. An example hook is located in the examples directory at the base of this repo.

--- a/spec/cmd_spec.sh
+++ b/spec/cmd_spec.sh
@@ -174,47 +174,4 @@ post"
       The stderr should equal "stderr"
     End
   End
-
-  Context 'wrapcmd honors validate hook in 0 case'
-    # The "command"
-    foo() {
-      printf "stdout\n"
-      printf "stderr\n" >&2
-      return 0
-    }
-
-    Before 'wrapsetup'
-    After 'wrapteardown'
-
-    wrapsetup() {
-      DEBUG=whynot wrapcmd foo
-    }
-
-    wrapteardown() {
-      unset DEBUG
-    }
-
-    Before 'hooksetup'
-    After 'hookteardown'
-
-    hooksetup() {
-      validate() {
-        printf "validate\n"
-        return 0
-      }
-      export FOOVALIDATEHOOK=validate
-    }
-
-    hookteardown() {
-      unset FOOVALIDATEHOOK
-    }
-
-    It 'calls validate hook for foo "command"'
-      When call sutfoo
-      The status should equal 0
-      The stdout should equal "validate
-stdout"
-      The stderr should equal "stderr"
-    End
-  End
 End

--- a/spec/cmd_spec.sh
+++ b/spec/cmd_spec.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+_base=$(basename "$0")
+_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
+export _base _dir
+
+export SOURCEPREFIX="${_base}"
+
+# This is only used for testing the wrapper. A user should never set this to
+# designate system under test.
+export SUT=true
+
+Describe 'cmd.sh'
+  Include sh/internal.sh
+  Include sh/cmd.sh
+
+  # Here to do initial testing of if the function behaves Since ls probably
+  #exists everywhere just picking on it, we won't test with it just using it as
+  #a canary for the wrap function itself.
+  Context 'wrapcmd ls works without DEBUG set'
+    It 'wraps ls'
+      When call wrapcmd ls
+      The status should equal 0
+    End
+  End
+
+  Context 'wrapcmd ls works with DEBUG set'
+    Before 'wrapsetup'
+    After 'wrapteardown'
+
+    wrapsetup() {
+      export DEBUG=sure
+    }
+
+    wrapteardown() {
+      unset DEBUG
+    }
+
+    It 'wraps ls'
+      When call wrapcmd ls
+      The status should equal 0
+    End
+  End
+
+  Context 'wrapcmd behaves in rc 0 case'
+    # The "command"
+    foo() {
+      printf "stdout\n"
+      printf "stderr\n" >&2
+      return 0
+    }
+
+    Before 'wrapsetup'
+    After 'wrapteardown'
+
+    wrapsetup() {
+      DEBUG=whynot wrapcmd foo
+    }
+
+    wrapteardown() {
+      unset DEBUG
+    }
+
+    It 'wraps foo "command"'
+      When call sutfoo
+      The status should equal 0
+      The stdout should equal "stdout"
+      The stderr should equal "stderr"
+    End
+  End
+
+  Context 'wrapcmd honors pre hook in 0 case'
+    # The "command"
+    foo() {
+      printf "stdout\n"
+      printf "stderr\n" >&2
+      return 0
+    }
+
+    Before 'wrapsetup'
+    After 'wrapteardown'
+
+    wrapsetup() {
+      DEBUG=whynot wrapcmd foo
+    }
+
+    wrapteardown() {
+      unset DEBUG
+    }
+
+    Before 'hooksetup'
+    After 'hookteardown'
+
+    hooksetup() {
+      pre() {
+        printf "pre\n"
+      }
+      export FOOPREHOOK=pre
+    }
+
+    hookteardown() {
+      unset FOOPREHOOK
+    }
+
+    It 'calls pre hook for foo "command"'
+      When call sutfoo
+      The status should equal 0
+      The stdout should equal "pre
+stdout"
+      The stderr should equal "stderr"
+    End
+  End
+
+  Context 'wrapcmd honors post hook in 0 case'
+    # The "command"
+    foo() {
+      printf "stdout\n"
+      printf "stderr\n" >&2
+      return 0
+    }
+
+    Before 'wrapsetup'
+    After 'wrapteardown'
+
+    wrapsetup() {
+      DEBUG=whynot wrapcmd foo
+    }
+
+    wrapteardown() {
+      unset DEBUG
+    }
+
+    Before 'hooksetup'
+    After 'hookteardown'
+
+    hooksetup() {
+      post() {
+        printf "post\n"
+      }
+      export FOOPOSTHOOK=post
+    }
+
+    hookteardown() {
+      unset FOOPOSTHOOK
+    }
+
+    It 'calls post hook for foo "command"'
+      When call sutfoo
+      The status should equal 0
+      The stdout should equal "stdout
+post"
+      The stderr should equal "stderr"
+    End
+  End
+
+  Context 'wrapcmd honors validate hook in 0 case'
+    # The "command"
+    foo() {
+      printf "stdout\n"
+      printf "stderr\n" >&2
+      return 0
+    }
+
+    Before 'wrapsetup'
+    After 'wrapteardown'
+
+    wrapsetup() {
+      DEBUG=whynot wrapcmd foo
+    }
+
+    wrapteardown() {
+      unset DEBUG
+    }
+
+    Before 'hooksetup'
+    After 'hookteardown'
+
+    hooksetup() {
+      validate() {
+        printf "validate\n"
+        return 0
+      }
+      export FOOVALIDATEHOOK=validate
+    }
+
+    hookteardown() {
+      unset FOOVALIDATEHOOK
+    }
+
+    It 'calls validate hook for foo "command"'
+      When call sutfoo
+      The status should equal 0
+      The stdout should equal "validate
+stdout"
+      The stderr should equal "stderr"
+    End
+  End
+End

--- a/spec/internal_spec.sh
+++ b/spec/internal_spec.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 #
 # MIT License
 #
@@ -21,20 +22,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+_base=$(basename "$0")
+_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
+export _base _dir
 
-# All lib shell should Presume to be run with set -e and set -u. Pipes are and
-# should be allowed to fail within this library, pipefile is not portable and
-# shouldn't be depended upon for error checking. If a command fails that needs
-# to be checked not piped into another command.
+Describe 'internal.sh'
+  Include sh/internal.sh
 
-# Note in posix shell there is no way to know at source time where one is
-# sourced. So we require caller scripts to provide that information in
-# $SOURCEPREFIX as executing shells do have that information.
+  Context 'mkrundir() creates directory in RUNDIR'
+    It 'creates a dir when called'
+      When call mkrundir
+      The path "${RUNDIR}" should be directory
+      End
 
-# Note: Order of imports is important, will eventually automate this.
-. "${SOURCEPREFIX?}/internal.sh"
-. "${SOURCEPREFIX?}/logger.sh"
-. "${SOURCEPREFIX?}/cmd.sh"
-
-# Don't import lib.sh directly in shellspec tests, this is why.
-trap libcleanup EXIT
+    It 'is cleaned up when libcleanup is called'
+      When call libcleanup
+      The path "${RUNDIR}" should not be directory
+      The path "${RUNDIR}" should not be file
+    End
+  End
+End


### PR DESCRIPTION
### Summary and Scope

CASMPET-6044 Update wrapcmd and associated tooling/examples. I removed one of the hook function types as it seemed redundant/unnecessary with the current setup.

Additionally removed the need for callers to call/setup the trap function when sourcing lb.sh. Added a default post hook that dumps out data like:


- Fixes: Random bugs found while testing I'll add more unit tests to catch them better but as this is MVP for now more validating behavior
- Requires: https://github.com/Cray-HPE/csm-common-library/pull/4
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
n/a
 
### Risks and Mitigations
 
Over and above the mvp in pr 4, this fixes random bugs in the hook setup for wrapcmd. So more risk not to have it until i can get way more unit tests around the overall hooks in place already.
