### PR TITLE
Make lib.sh a bit more explicit about requiring SOURCEPREFIX

### DIFF
--- a/sh/lib.sh
+++ b/sh/lib.sh
@@ -28,14 +28,23 @@
 # to be checked not piped into another command.
 
 # Note in posix shell there is no way to know at source time where one is
-# sourced. So we require caller scripts to provide that information in
-# $SOURCEPREFIX as executing shells do have that information.
+# sourced from a sourced file. So we require caller scripts to provide that
+# information in $SOURCEPREFIX as executing shells do have that information.
+#
+# Yes BASH_SOURCE allows this, but that doesn't work on dash, or ash, or
+# anything other than bash and our intent here is to run in busybox containers
+# as well as ubuntu.
 
 # Note: Order of imports is important, will eventually automate this.
-. "${SOURCEPREFIX?}/internal.sh"
-. "${SOURCEPREFIX?}/logger.sh"
-. "${SOURCEPREFIX?}/cmd.sh"
-. "${SOURCEPREFIX?}/yaml.sh"
+if [ -n "${SOURCEPREFIX}" ]; then
+  . "${SOURCEPREFIX}/internal.sh"
+  . "${SOURCEPREFIX}/logger.sh"
+  . "${SOURCEPREFIX}/cmd.sh"
+  . "${SOURCEPREFIX}/yaml.sh"
 
-# Don't import lib.sh directly in shellspec tests, this is why.
-trap libcleanup EXIT
+  # Don't import lib.sh directly in shellspec tests, this is why.
+  trap libcleanup EXIT
+else
+  # Nothing will be sourced in this case
+  printf "You must set SOURCEPREFIX to the base directory of lib.sh in before sourcing this library!\n" >&2
+fi


### PR DESCRIPTION
### Summary and Scope

Make lib.sh explicit about requiring SOURCEPREFIX to be set.

Looks like so now:
```
$ (set -x; SOURCEPREFIX=$(pwd)/sh . ./sh/lib.sh)       
+zsh:68> SOURCEPREFIX=+zsh:68> pwd
+zsh:68> SOURCEPREFIX=/Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh +zsh:68> . ./sh/lib.sh
+./sh/lib.sh:39> [ -n /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh ']'
+./sh/lib.sh:40> . /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/internal.sh
+/Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/internal.sh:26> RUNDIR=/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T//csm-common-lib-44735
+./sh/lib.sh:41> . /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/logger.sh
+/Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/logger.sh:50> SEVERITY='EMERG ALERT CRIT ERROR WARN NOTICE INFO DEBUG'
+/Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/logger.sh:53> LOG_LEVEL=warn
+./sh/lib.sh:42> . /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/cmd.sh
+./sh/lib.sh:43> . /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library/sh/yaml.sh
+./sh/lib.sh:46> trap libcleanup EXIT
+zsh:68> libcleanup
+libcleanup:1> rm -fr /var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T//csm-common-lib-44735
$ ./sh/lib.sh
You must set SOURCEPREFIX to the base directory of lib.sh in before sourcing this library!
```

- Fixes:
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
n/a
 
### Risks and Mitigations
 
n/a

-->
